### PR TITLE
Generate C headers inside Cargo build step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "rustls 0.16.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalink)",
  "sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?tag=v1.1.0)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.0 (git+https://github.com/mesalock-linux/webpki?tag=v1.1.0)",
  "webpki-roots 0.17.0 (git+https://github.com/mesalock-linux/webpki-roots?tag=v1.1.0)",
 ]
@@ -393,6 +394,14 @@ dependencies = [
 name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "scopeguard"
@@ -545,6 +554,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "2.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -732,6 +751,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalink)" = "<none>"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.6.0 (git+https://github.com/mesalock-linux/sct.rs?tag=v1.1.0)" = "<none>"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -754,6 +774,7 @@ dependencies = [
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "4de97fa1806bb1a99904216f6ac5e0c050dc4f8c676dc98775047c38e5c01b55"
 "checksum wasm-bindgen-backend 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "5d82c170ef9f5b2c63ad4460dfcee93f3ec04a9a36a4cc20bc973c39e59ab8e3"
 "checksum wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f07d50f74bf7a738304f6b8157f4a581e1512cd9e9cdb5baad8c31bbe8ffd81d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ git = "https://github.com/mesalock-linux/webpki-roots"
 tag = "v1.1.0"
 default-features = false
 
+[build-dependencies]
+walkdir = "2"
+
 [dev-dependencies]
 log = "0.4"
 env_logger = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["tls", "ssl", "rust"]
 homepage = "https://github.com/mesalock-linux/mesalink"
 repository = "https://github.com/mesalock-linux/mesalink"
 categories = ["network-programming"]
+links = "mesalink"
 build = "build.rs"
 
 [badges]

--- a/build.rs
+++ b/build.rs
@@ -98,14 +98,16 @@ fn generate_headers() -> std::io::Result<()> {
     )?;
 
     let mut options_h = fs::File::create(include_dir.join("mesalink/options.h"))?;
-    options_h.write_all(b"\
+    options_h.write_all(
+        b"\
         #ifndef MESALINK_OPTIONS_H\n\
         #define MESALINK_OPTIONS_H\n\n\
 
         #ifdef __cplusplus\n\
         extern \"C\" {\n\
         #endif\n\n\
-    ")?;
+    ",
+    )?;
 
     fn write_define(mut writer: impl Write, name: &str) -> std::io::Result<()> {
         write!(writer, "\n#undef {}\n#define {}\n", name, name)
@@ -171,13 +173,15 @@ fn generate_headers() -> std::io::Result<()> {
         write_define(&mut options_h, "NO_SGX")?;
     }
 
-    options_h.write_all(b"\n\
+    options_h.write_all(
+        b"\n\
         #ifdef __cplusplus\n\
         }\n\
         #endif\n\
 
         #endif /* MESALINK_OPTIONS_H */\n\
-    ")?;
+    ",
+    )?;
 
     println!("cargo:include={}", include_dir.display());
 

--- a/build.rs
+++ b/build.rs
@@ -13,13 +13,15 @@
  *
  */
 
+use std::env;
+use std::fs;
+use std::io::prelude::*;
+use std::path::PathBuf;
+use walkdir::WalkDir;
+
 #[cfg(unix)]
 fn generate_la(lib: &str) -> std::io::Result<()> {
-    use std::env;
-    use std::fs;
     use std::fs::File;
-    use std::io::prelude::*;
-    use std::path::PathBuf;
 
     let self_version = env!("CARGO_PKG_VERSION");
     let top_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -68,7 +70,123 @@ fn generate_la(_lib: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+fn generate_headers() -> std::io::Result<()> {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let include_dir = out_dir.join("include");
+
+    println!("cargo:rerun-if-changed=mesalink");
+
+    let header_files = WalkDir::new("mesalink")
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| match e.path().extension() {
+            Some(extension) => extension == "h",
+            None => false,
+        });
+
+    for src in header_files {
+        let dest = include_dir.join(src.path());
+        fs::create_dir_all(dest.parent().unwrap())?;
+        fs::copy(src.path(), dest)?;
+    }
+
+    let version_h = fs::read_to_string("mesalink/version.h.in")?;
+    fs::write(
+        include_dir.join("mesalink/version.h"),
+        version_h.replace("@VERSION@", env::var("CARGO_PKG_VERSION").unwrap().as_str()),
+    )?;
+
+    let mut options_h = fs::File::create(include_dir.join("mesalink/options.h"))?;
+    options_h.write_all(b"\
+        #ifndef MESALINK_OPTIONS_H\n\
+        #define MESALINK_OPTIONS_H\n\n\
+
+        #ifdef __cplusplus\n\
+        extern \"C\" {\n\
+        #endif\n\n\
+    ")?;
+
+    fn write_define(mut writer: impl Write, name: &str) -> std::io::Result<()> {
+        write!(writer, "\n#undef {}\n#define {}\n", name, name)
+    }
+
+    if cfg!(feature = "client_apis") {
+        write_define(&mut options_h, "HAVE_CLIENT")?;
+    } else {
+        write_define(&mut options_h, "NO_CLIENT")?;
+    }
+
+    if cfg!(feature = "server_apis") {
+        write_define(&mut options_h, "HAVE_SERVER")?;
+    } else {
+        write_define(&mut options_h, "NO_SERVER")?;
+    }
+
+    if cfg!(feature = "error_strings") {
+        write_define(&mut options_h, "HAVE_ERROR_STRINGS")?;
+    } else {
+        write_define(&mut options_h, "NO_ERROR_STRINGS")?;
+    }
+
+    if cfg!(feature = "aesgcm") {
+        write_define(&mut options_h, "HAVE_AESGCM")?;
+    } else {
+        write_define(&mut options_h, "NO_AESGCM")?;
+    }
+
+    if cfg!(feature = "chachapoly") {
+        write_define(&mut options_h, "HAVE_CHACHAPOLY")?;
+    } else {
+        write_define(&mut options_h, "NO_CHACHAPOLY")?;
+    }
+
+    if cfg!(feature = "tls13") {
+        write_define(&mut options_h, "HAVE_TLS13")?;
+    } else {
+        write_define(&mut options_h, "NO_TLS13")?;
+    }
+
+    if cfg!(feature = "x25519") {
+        write_define(&mut options_h, "HAVE_X25519")?;
+    } else {
+        write_define(&mut options_h, "NO_X25519")?;
+    }
+
+    if cfg!(feature = "ecdh") {
+        write_define(&mut options_h, "HAVE_ECDH")?;
+    } else {
+        write_define(&mut options_h, "NO_ECDH")?;
+    }
+
+    if cfg!(feature = "ecdsa") {
+        write_define(&mut options_h, "HAVE_ECDSA")?;
+    } else {
+        write_define(&mut options_h, "NO_ECDSA")?;
+    }
+
+    if cfg!(feature = "sgx") {
+        write_define(&mut options_h, "HAVE_SGX")?;
+    } else {
+        write_define(&mut options_h, "NO_SGX")?;
+    }
+
+    options_h.write_all(b"\n\
+        #ifdef __cplusplus\n\
+        }\n\
+        #endif\n\
+
+        #endif /* MESALINK_OPTIONS_H */\n\
+    ")?;
+
+    println!("cargo:include={}", include_dir.display());
+
+    Ok(())
+}
+
 fn main() {
     let lib_name = format!("{}{}", "lib", std::env::var("CARGO_PKG_NAME").unwrap(),);
     let _ = generate_la(lib_name.as_str());
+
+    generate_headers().unwrap();
 }


### PR DESCRIPTION
Generate C headers in the same manner as CMake / Autotools, but inside `build.rs`. The generated headers are written to a directory inside `$OUT_DIR` provided by Cargo.

This has no effect when producing a standalone binary for use in a C/C++ application, but when MesaLink is used in a Rust application, it allows other `-sys` crates to access the MesaLink headers during compilation for any other C code that may need them.

When MesaLink is added as a Cargo dependency, Cargo will now pass a `DEP_MESALINK_INCLUDE` environment variable to dependent crates' build scripts, whose value is a path to the generated `include` directory.

This is being added for the sake of `curl-sys`, but is a general-purpose solution.