### PR TITLE
Various Windows compatibility fixes

### DIFF
--- a/mesalink/openssl/ssl.h
+++ b/mesalink/openssl/ssl.h
@@ -130,10 +130,10 @@ extern "C" {
 #ifdef HAVE_WINDOWS
 #define SSL_set_socket mesalink_SSL_set_socket
 #define SSL_get_socket mesalink_SSL_get_socket
-#else
+#endif
+
 #define SSL_set_fd mesalink_SSL_set_fd
 #define SSL_get_fd mesalink_SSL_get_fd
-#endif
 
 #define SSL_do_handshake mesalink_SSL_do_handshake
 

--- a/mesalink/ssl.h
+++ b/mesalink/ssl.h
@@ -161,10 +161,10 @@ MESALINK_API int mesalink_SSL_do_handshake(MESALINK_SSL *);
 #include <winsock2.h>
 MESALINK_API int mesalink_SSL_set_socket(MESALINK_SSL *, SOCKET);
 MESALINK_API SOCKET mesalink_SSL_get_socket(const MESALINK_SSL *);
-#else
+#endif
+
 MESALINK_API int mesalink_SSL_set_fd(MESALINK_SSL *, int);
 MESALINK_API int mesalink_SSL_get_fd(const MESALINK_SSL *);
-#endif
 
 #ifdef HAVE_CLIENT
 MESALINK_API int mesalink_SSL_connect(MESALINK_SSL *);

--- a/src/libcrypto/bio.rs
+++ b/src/libcrypto/bio.rs
@@ -783,7 +783,7 @@ impl<T: AsRawFd> OpenFileStream for T {
 impl<T: AsRawHandle> OpenFileStream for T {
     unsafe fn open_file_stream_r(&self) -> *mut libc::FILE {
         let handle = self.as_raw_handle();
-        match libc::open_osfhandle(handle, 0) {
+        match libc::open_osfhandle(handle as libc::intptr_t, 0) {
             -1 => ptr::null_mut(),
             fd => libc::fdopen(fd, b"r\0".as_ptr() as *const c_char),
         }
@@ -791,7 +791,7 @@ impl<T: AsRawHandle> OpenFileStream for T {
 
     unsafe fn open_file_stream_w(&self) -> *mut libc::FILE {
         let handle = self.as_raw_handle();
-        match libc::open_osfhandle(handle, 0) {
+        match libc::open_osfhandle(handle as libc::intptr_t, 0) {
             -1 => ptr::null_mut(),
             fd => libc::fdopen(fd, b"w\0".as_ptr() as *const c_char),
         }

--- a/src/libcrypto/bio.rs
+++ b/src/libcrypto/bio.rs
@@ -24,9 +24,9 @@ use std::{ffi, fs, io, mem, ptr, slice};
 use std::io::{Read, Seek, Write};
 use std::ops::{Deref, DerefMut};
 #[cfg(unix)]
-use std::os::unix::io::{FromRawFd, IntoRawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 #[cfg(windows)]
-use std::os::windows::io::{FromRawHandle, IntoRawHandle};
+use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
 
 #[doc(hidden)]
 pub trait BioRW: Read + Write + Seek {}
@@ -605,14 +605,7 @@ fn inner_mesalink_bio_new_fp<'a>(
     if stream.is_null() {
         return Err(error!(MesalinkBuiltinError::NullPointer.into()));
     }
-    #[cfg(unix)]
-    let file = unsafe { fs::File::from_raw_fd(libc::fileno(stream)) };
-    #[cfg(windows)]
-    let file = unsafe {
-        let fd = libc::fileno(stream);
-        let osf_handle = libc::get_osfhandle(fd);
-        fs::File::from_raw_handle(osf_handle as *mut _)
-    };
+    let file = unsafe { fs::File::from_file_stream(stream) };
     let flags =
         BioFlags::from_bits(flags as u32).ok_or(error!(MesalinkBuiltinError::BadFuncArg.into()))?;
     let bio = MESALINK_BIO {
@@ -631,7 +624,6 @@ fn inner_mesalink_bio_new_fp<'a>(
 ///
 /// BIO_set_fp(BIO *b,FILE *fp, int flags);
 /// ```
-#[cfg(unix)]
 #[no_mangle]
 pub extern "C" fn mesalink_BIO_set_fp(
     bio_ptr: *mut MESALINK_BIO<'_>,
@@ -644,15 +636,13 @@ pub extern "C" fn mesalink_BIO_set_fp(
     );
 }
 
-#[cfg(unix)]
 fn inner_mesalink_bio_set_fp(
     bio_ptr: *mut MESALINK_BIO<'_>,
     fp: *mut libc::FILE,
     flags: c_int,
 ) -> MesalinkInnerResult<c_int> {
     let bio = sanitize_ptr_for_mut_ref(bio_ptr)?;
-    let fd = unsafe { libc::fileno(fp) };
-    let file = unsafe { fs::File::from_raw_fd(fd) };
+    let file = unsafe { fs::File::from_file_stream(fp) };
     let flags =
         BioFlags::from_bits(flags as u32).ok_or(error!(MesalinkBuiltinError::BadFuncArg.into()))?;
     bio.inner = MesalinkBioInner::File(file);
@@ -750,12 +740,69 @@ pub extern "C" fn mesalink_BIO_new_mem_buf<'a>(
     Box::into_raw(Box::new(bio)) as *mut MESALINK_BIO<'_>
 }
 
+/// Helper trait for converting from FILE* in libc.
+pub(crate) trait FromFileStream {
+    unsafe fn from_file_stream(stream: *mut libc::FILE) -> Self;
+}
+
+#[cfg(unix)]
+impl<T: FromRawFd> FromFileStream for T {
+    unsafe fn from_file_stream(stream: *mut libc::FILE) -> Self {
+        Self::from_raw_fd(libc::fileno(stream))
+    }
+}
+
+#[cfg(windows)]
+impl<T: FromRawHandle> FromFileStream for T {
+    unsafe fn from_file_stream(stream: *mut libc::FILE) -> Self {
+        let fd = libc::fileno(stream);
+        let osf_handle = libc::get_osfhandle(fd);
+        Self::from_raw_handle(osf_handle as *mut _)
+    }
+}
+
+/// Helper trait for converting to FILE* in libc.
+pub(crate) trait OpenFileStream {
+    unsafe fn open_file_stream_r(&self) -> *mut libc::FILE;
+
+    unsafe fn open_file_stream_w(&self) -> *mut libc::FILE;
+}
+
+#[cfg(unix)]
+impl<T: AsRawFd> OpenFileStream for T {
+    unsafe fn open_file_stream_r(&self) -> *mut libc::FILE {
+        libc::fdopen(self.as_raw_fd(), b"r\0".as_ptr() as *const c_char)
+    }
+
+    unsafe fn open_file_stream_w(&self) -> *mut libc::FILE {
+        libc::fdopen(self.as_raw_fd(), b"w\0".as_ptr() as *const c_char)
+    }
+}
+
+#[cfg(windows)]
+impl<T: AsRawHandle> OpenFileStream for T {
+    unsafe fn open_file_stream_r(&self) -> *mut libc::FILE {
+        let handle = self.as_raw_handle();
+        match libc::open_osfhandle(handle, 0) {
+            -1 => ptr::null_mut(),
+            fd => libc::fdopen(fd, b"r\0".as_ptr() as *const c_char),
+        }
+    }
+
+    unsafe fn open_file_stream_w(&self) -> *mut libc::FILE {
+        let handle = self.as_raw_handle();
+        match libc::open_osfhandle(handle, 0) {
+            -1 => ptr::null_mut(),
+            fd => libc::fdopen(fd, b"w\0".as_ptr() as *const c_char),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use libc::{self, c_char, c_void};
     use std::fs;
-    use std::os::unix::io::AsRawFd;
 
     #[test]
     fn bio_methods() {
@@ -859,8 +906,7 @@ mod tests {
         assert_eq!(bio_ptr_f, ptr::null_mut());
 
         let file = fs::File::open("tests/ca.cert").unwrap(); // Read-only, "r"
-        let fd = file.as_raw_fd();
-        let fp = unsafe { libc::fdopen(fd, b"r\0".as_ptr() as *const c_char) };
+        let fp = unsafe { file.open_file_stream_r() };
         assert_ne!(fp, ptr::null_mut());
 
         let bio_ptr_f = mesalink_BIO_new_fp(fp, 0);
@@ -871,8 +917,7 @@ mod tests {
     #[test]
     fn bio_file_set_fp() {
         let file = fs::File::open("tests/ca.cert").unwrap(); // Read-only, "r"
-        let fd = file.as_raw_fd();
-        let fp = unsafe { libc::fdopen(fd, b"r\0".as_ptr() as *const c_char) };
+        let fp = unsafe { file.open_file_stream_r() };
         assert_ne!(fp, ptr::null_mut());
 
         let bio_ptr_f = mesalink_BIO_new(mesalink_BIO_s_file());

--- a/src/libcrypto/pem.rs
+++ b/src/libcrypto/pem.rs
@@ -236,11 +236,10 @@ fn extract_one<A>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::libcrypto::{bio, evp};
+    use crate::libcrypto::{bio, bio::OpenFileStream, evp};
     use crate::libssl::x509;
     use libc::c_char;
     use std::fs;
-    use std::os::unix::io::AsRawFd;
 
     #[test]
     fn pem_read_bio_private_key() {
@@ -263,8 +262,7 @@ mod test {
     #[test]
     fn pem_read_private_key() {
         let file = fs::File::open("tests/end.key").unwrap(); // Read-only, "r"
-        let fd = file.as_raw_fd();
-        let fp = unsafe { libc::fdopen(fd, b"r\0".as_ptr() as *const c_char) };
+        let fp = unsafe { file.open_file_stream_r() };
         assert_ne!(fp, ptr::null_mut());
         let pkey_ptr =
             mesalink_PEM_read_PrivateKey(fp, ptr::null_mut(), ptr::null_mut(), ptr::null_mut());
@@ -289,8 +287,7 @@ mod test {
     #[test]
     fn pem_read_x509() {
         let file = fs::File::open("tests/end.fullchain").unwrap(); // Read-only, "r"
-        let fd = file.as_raw_fd();
-        let fp = unsafe { libc::fdopen(fd, b"r\0".as_ptr() as *const c_char) };
+        let fp = unsafe { file.open_file_stream_r() };
         assert_ne!(fp, ptr::null_mut());
         let x509_ptr =
             mesalink_PEM_read_X509(fp, ptr::null_mut(), ptr::null_mut(), ptr::null_mut());

--- a/src/libcrypto/pem.rs
+++ b/src/libcrypto/pem.rs
@@ -294,5 +294,4 @@ mod test {
         assert_ne!(x509_ptr, ptr::null_mut());
         x509::mesalink_X509_free(x509_ptr);
     }
-
 }

--- a/src/libssl/err.rs
+++ b/src/libssl/err.rs
@@ -772,11 +772,10 @@ pub extern "C" fn mesalink_ERR_clear_error() {
 ///
 /// void ERR_print_errors_fp(FILE *fp);
 /// ```
-#[cfg(unix)]
 #[no_mangle]
 pub unsafe extern "C" fn mesalink_ERR_print_errors_fp(fp: *mut libc::FILE) {
+    use crate::libcrypto::bio::FromFileStream;
     use std::io::Write;
-    use std::os::unix::io::FromRawFd;
     use std::{fs, str};
     if fp.is_null() {
         return;
@@ -785,7 +784,7 @@ pub unsafe extern "C" fn mesalink_ERR_print_errors_fp(fp: *mut libc::FILE) {
     if fd < 0 {
         return;
     }
-    let mut file = fs::File::from_raw_fd(fd);
+    let mut file = fs::File::from_file_stream(fp);
     ERROR_QUEUE.with(|q| {
         let mut queue = q.borrow_mut();
         for e in queue.drain(0..) {
@@ -1253,16 +1252,15 @@ mod tests {
 
     #[test]
     fn err_print_errors_fp() {
+        use crate::libcrypto::bio::OpenFileStream;
         use std::io;
-        use std::os::unix::io::AsRawFd;
 
         mesalink_ERR_load_error_strings();
         ErrorQueue::push_error(error!(MesalinkBuiltinError::None.into()));
         ErrorQueue::push_error(error!(MesalinkBuiltinError::BadFuncArg.into()));
         ErrorQueue::push_error(error!(MesalinkBuiltinError::MalformedObject.into()));
-        let fd = io::stderr().as_raw_fd();
-        let mode = b"wb\0".as_ptr() as *const c_char;
-        let file = unsafe { libc::fdopen(fd, mode) };
+        let stderr = io::stderr();
+        let file = unsafe { stderr.open_file_stream_w() };
         unsafe {
             mesalink_ERR_print_errors_fp(file);
             mesalink_ERR_print_errors_fp(ptr::null_mut());

--- a/src/libssl/err.rs
+++ b/src/libssl/err.rs
@@ -1268,5 +1268,4 @@ mod tests {
         mesalink_ERR_clear_error();
         mesalink_ERR_free_error_strings();
     }
-
 }

--- a/src/libssl/ssl.rs
+++ b/src/libssl/ssl.rs
@@ -1967,8 +1967,8 @@ pub extern "C" fn mesalink_SSL_set_fd(ssl_ptr: *mut MESALINK_SSL, fd: c_int) -> 
     #[cfg(windows)]
     {
         check_inner_result!(
-        inner_mesalink_ssl_set_socket(ssl_ptr, fd as libc::SOCKET),
-        SSL_FAILURE
+            inner_mesalink_ssl_set_socket(ssl_ptr, fd as libc::SOCKET),
+            SSL_FAILURE
         )
     }
 }
@@ -2001,8 +2001,8 @@ pub extern "C" fn mesalink_SSL_get_fd(ssl_ptr: *mut MESALINK_SSL) -> c_int {
     #[cfg(windows)]
     {
         check_inner_result!(
-        inner_measlink_ssl_get_socket(ssl_ptr).map(|socket| socket as c_int),
-        SSL_FAILURE
+            inner_measlink_ssl_get_socket(ssl_ptr).map(|socket| socket as c_int),
+            SSL_FAILURE
         )
     }
 }

--- a/src/libssl/ssl.rs
+++ b/src/libssl/ssl.rs
@@ -1966,7 +1966,10 @@ pub extern "C" fn mesalink_SSL_set_fd(ssl_ptr: *mut MESALINK_SSL, fd: c_int) -> 
 
     #[cfg(windows)]
     {
-        check_inner_result!(inner_mesalink_ssl_set_socket(ssl_ptr, fd as libc::SOCKET), SSL_FAILURE)
+        check_inner_result!(
+        inner_mesalink_ssl_set_socket(ssl_ptr, fd as libc::SOCKET),
+        SSL_FAILURE
+        )
     }
 }
 
@@ -1997,7 +2000,10 @@ pub extern "C" fn mesalink_SSL_get_fd(ssl_ptr: *mut MESALINK_SSL) -> c_int {
 
     #[cfg(windows)]
     {
-        check_inner_result!(inner_measlink_ssl_get_socket(ssl_ptr), SSL_FAILURE) as c_int
+        check_inner_result!(
+        inner_measlink_ssl_get_socket(ssl_ptr).map(|socket| socket as c_int),
+        SSL_FAILURE
+        )
     }
 }
 

--- a/src/libssl/ssl.rs
+++ b/src/libssl/ssl.rs
@@ -1957,10 +1957,17 @@ fn inner_mesalink_ssl_set_tlsext_host_name(
 ///
 /// int SSL_set_fd(SSL *ssl, int fd);
 /// ```
-#[cfg(unix)]
 #[no_mangle]
 pub extern "C" fn mesalink_SSL_set_fd(ssl_ptr: *mut MESALINK_SSL, fd: c_int) -> c_int {
-    check_inner_result!(inner_mesalink_ssl_set_fd(ssl_ptr, fd), SSL_FAILURE)
+    #[cfg(unix)]
+    {
+        check_inner_result!(inner_mesalink_ssl_set_fd(ssl_ptr, fd), SSL_FAILURE)
+    }
+
+    #[cfg(windows)]
+    {
+        check_inner_result!(inner_mesalink_ssl_set_socket(ssl_ptr, fd as libc::SOCKET), SSL_FAILURE)
+    }
 }
 
 #[cfg(unix)]
@@ -1981,10 +1988,17 @@ fn inner_mesalink_ssl_set_fd(ssl_ptr: *mut MESALINK_SSL, fd: c_int) -> MesalinkI
 ///
 /// int SSL_get_fd(const SSL *ssl);
 /// ```
-#[cfg(unix)]
 #[no_mangle]
 pub extern "C" fn mesalink_SSL_get_fd(ssl_ptr: *mut MESALINK_SSL) -> c_int {
-    check_inner_result!(inner_measlink_ssl_get_fd(ssl_ptr), SSL_FAILURE)
+    #[cfg(unix)]
+    {
+        check_inner_result!(inner_measlink_ssl_get_fd(ssl_ptr), SSL_FAILURE)
+    }
+
+    #[cfg(windows)]
+    {
+        check_inner_result!(inner_measlink_ssl_get_socket(ssl_ptr), SSL_FAILURE) as c_int
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Make the following functions compatible with Windows:

- `BIO_set_fp`
- `ERR_print_errors_fp`
- `SSL_get_fp`
- `SSL_set_fp`

Introduce two new internal traits that reduce platform-specific boilerplate for converting to and from `FILE*` and native file handles.

It so happens that libcurl is a consumer of a few of these. This should be what it takes to get MesaLink + curl on all major platforms.